### PR TITLE
Add button toggle stats to enable/disable stats

### DIFF
--- a/src/components/Buttons/ToggleStatsButton/ToggleStatsButton.tsx
+++ b/src/components/Buttons/ToggleStatsButton/ToggleStatsButton.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback, useEffect } from 'react';
+import Button from '@material-ui/core/Button';
+import clsx from 'clsx';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+import useStatsListener from '../../../hooks/useStatsListener/useStatsListener';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    button: {
+      background: theme.brand,
+      color: 'white',
+      '&:hover': {
+        background: '#600101',
+      },
+    },
+  })
+);
+
+export default function ToggleStatsButton(props: { className?: string }) {
+  const classes = useStyles();
+  const [isStatsEnabled, stats, toggleStatsListener] = useStatsListener();
+
+  useEffect(() => {
+    if (stats) {
+      console.log('[statsListener]', stats);
+    }
+  }, [stats]);
+
+  useEffect(() => {
+    console.log(`[statsListener] is ${isStatsEnabled ? 'enabled' : 'disabled'}`);
+  }, [isStatsEnabled]);
+
+  const toggleStats = useCallback(() => {
+    toggleStatsListener();
+  }, [toggleStatsListener]);
+
+  return (
+    <Button
+      className={clsx(classes.button, props.className)}
+      onClick={toggleStats}
+      style={{ margin: '0 0 0 10px' }}
+      data-cy-toggle-stats
+    >
+      {!isStatsEnabled ? 'Enable Stats' : 'Disable Stats'}
+    </Button>
+  );
+}

--- a/src/components/MenuBar/MenuBar.tsx
+++ b/src/components/MenuBar/MenuBar.tsx
@@ -16,6 +16,7 @@ import { Typography, Grid, Hidden } from '@material-ui/core';
 import ToggleAudioButton from '../Buttons/ToggleAudioButton/ToggleAudioButton';
 import ToggleVideoButton from '../Buttons/ToggleVideoButton/ToggleVideoButton';
 import ToggleScreenShareButton from '../Buttons/ToogleScreenShareButton/ToggleScreenShareButton';
+import ToggleStatsButton from '../Buttons/ToggleStatsButton/ToggleStatsButton';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -108,6 +109,7 @@ export default function MenuBar() {
                 <EndCallButton />
                 <NailUpEndCallButton />
                 <NailUpJoinCallButton />
+                <ToggleStatsButton />
               </Grid>
             </Grid>
           </Hidden>

--- a/src/hooks/useStatsListener/useStatsListener.tsx
+++ b/src/hooks/useStatsListener/useStatsListener.tsx
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react';
+import watchRTC from '@testrtc/watchrtc-sdk';
+
+export default function useStatsListener() {
+  const [isStatsEnabled, setIsStatsEnabled] = useState(false);
+  const [stats, setStats] = useState(null);
+
+  const statsListener = (statsReceived: any) => {
+    setStats(statsReceived);
+  };
+
+  const toggleStatsListener = useCallback(() => {
+    if (!isStatsEnabled && watchRTC) {
+      watchRTC.addStatsListener(statsListener);
+      setIsStatsEnabled(true);
+    } else {
+      watchRTC.addStatsListener(null);
+      setIsStatsEnabled(false);
+    }
+  }, [isStatsEnabled]);
+
+  return [isStatsEnabled, stats, toggleStatsListener] as const;
+}


### PR DESCRIPTION
A new toggle button has been added "Enable Stats" / "Disable Stats" to the UI
When enabled, stats are displayed in the console logs

Need to update sample with WatchRTC SDK > 1.38.beta5 in order to work