### PR TITLE
RTC-5081 MAX_ALLOWED_SESSION_DURATION moved to .env

### DIFF
--- a/functions/get-token/get-twilio-token.js
+++ b/functions/get-token/get-twilio-token.js
@@ -1,7 +1,7 @@
 const AccessToken = require('twilio').jwt.AccessToken;
 const VideoGrant = AccessToken.VideoGrant;
 
-const MAX_ALLOWED_SESSION_DURATION = 14400;
+const MAX_ALLOWED_SESSION_DURATION = process.env.MAX_ALLOWED_SESSION_DURATION;
 const twilioAccountSid = process.env.TWILIO_ACCOUNT_SID;
 const twilioApiKeySID = process.env.TWILIO_API_KEY_SID;
 const twilioApiKeySecret = process.env.TWILIO_API_KEY_SECRET;


### PR DESCRIPTION
This pull request makes a configuration improvement to the `get-twilio-token.js` function by allowing the maximum allowed session duration to be set via an environment variable instead of a hardcoded value.

Configuration improvement:

* Changed `MAX_ALLOWED_SESSION_DURATION` to be sourced from the `MAX_ALLOWED_SESSION_DURATION` environment variable, making session duration configurable without code changes.